### PR TITLE
feat: drag n drop: reorder lists and cards

### DIFF
--- a/actions/update-card-order/index.ts
+++ b/actions/update-card-order/index.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { auth } from "@clerk/nextjs";
+
+import { db } from "@/lib/db";
+import { createSafeAction } from "@/lib/create-safe-action";
+
+import { InputType, ReturnType } from "./types";
+import { UpdateCardOrder } from "./schema";
+
+const handler = async (data: InputType): Promise<ReturnType> => {
+    const { userId, orgId } = auth();
+
+    if (!userId || !orgId) {
+        return {
+            error: "Unauthorized",
+        };
+    }
+
+    const { items, boardId } = data;
+    let updatedCards;
+
+    try {
+        const transacttion = items.map((card) =>
+            db.card.update({
+                where: {
+                    id: card.id,
+                    list: {
+                        board: {
+                            orgId,
+                        },
+                    },
+                },
+                data: {
+                    order: card.order,
+                    listId: card.listId,
+                },
+            })
+        );
+
+        updatedCards = await db.$transaction(transacttion);
+    } catch (error) {
+        return {
+            error: "Failed to reorder.",
+        };
+    }
+
+    revalidatePath(`/board/${boardId}`);
+
+    return { data: updatedCards };
+};
+
+export const updateCardOrder = createSafeAction(UpdateCardOrder, handler);

--- a/actions/update-card-order/schema.ts
+++ b/actions/update-card-order/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const UpdateCardOrder = z.object({
+    items: z.array(
+        z.object({
+            id: z.string(),
+            title: z.string(),
+            order: z.number(),
+            listId: z.string(),
+            createdAt: z.date(),
+            updatedAt: z.date(),
+        })
+    ),
+    boardId: z.string(),
+});

--- a/actions/update-card-order/types.ts
+++ b/actions/update-card-order/types.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { Card } from "@prisma/client";
+
+import { ActionState } from "@/lib/create-safe-action";
+
+import { UpdateCardOrder } from "./schema";
+
+export type InputType = z.infer<typeof UpdateCardOrder>;
+export type ReturnType = ActionState<InputType, Card[]>;

--- a/actions/update-list-order/index.ts
+++ b/actions/update-list-order/index.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { auth } from "@clerk/nextjs";
+
+import { db } from "@/lib/db";
+import { createSafeAction } from "@/lib/create-safe-action";
+
+import { InputType, ReturnType } from "./types";
+import { UpdateListOrder } from "./schema";
+
+const handler = async (data: InputType): Promise<ReturnType> => {
+    const { userId, orgId } = auth();
+
+    if (!userId || !orgId) {
+        return {
+            error: "Unauthorized",
+        };
+    }
+
+    const { boardId, items } = data;
+    let lists;
+
+    try {
+        const transacttion = items.map((list) =>
+            // instant return
+            db.list.update({
+                where: {
+                    id: list.id,
+                    board: {
+                        orgId,
+                    },
+                },
+                data: {
+                    order: list.order,
+                },
+            })
+        );
+
+        lists = await db.$transaction(transacttion);
+    } catch (error) {
+        return {
+            error: "Failed to reorder.",
+        };
+    }
+
+    revalidatePath(`/board/${boardId}`);
+
+    return { data: lists };
+};
+
+export const updateListOrder = createSafeAction(UpdateListOrder, handler);

--- a/actions/update-list-order/schema.ts
+++ b/actions/update-list-order/schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const UpdateListOrder = z.object({
+    items: z.array(
+        z.object({
+            id: z.string(),
+            title: z.string(),
+            order: z.number(),
+            createdAt: z.date(),
+            updatedAt: z.date(),
+        })
+    ),
+    boardId: z.string(),
+});

--- a/actions/update-list-order/types.ts
+++ b/actions/update-list-order/types.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { List } from "@prisma/client";
+
+import { ActionState } from "@/lib/create-safe-action";
+
+import { UpdateListOrder } from "./schema";
+
+export type InputType = z.infer<typeof UpdateListOrder>;
+export type ReturnType = ActionState<InputType, List[]>;

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/card-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/card-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card } from "@prisma/client";
+import { Draggable } from "@hello-pangea/dnd";
 
 interface CardItemProps {
     index: number;
@@ -9,11 +10,18 @@ interface CardItemProps {
 
 export const CardItem = ({ index, data }: CardItemProps) => {
     return (
-        <div
-            role="button"
-            className="truncate border-2 border-transparent hover:border-black py-2 px-3 text-sm bg-white rounded-md shadow-sm"
-        >
-            {data.title}
-        </div>
+        <Draggable draggableId={data.id} index={index}>
+            {(provided) => (
+                <div
+                    {...provided.draggableProps}
+                    {...provided.dragHandleProps}
+                    ref={provided.innerRef}
+                    role="button"
+                    className="truncate border-2 border-transparent hover:border-black py-2 px-3 text-sm bg-white rounded-md shadow-sm"
+                >
+                    {data.title}
+                </div>
+            )}
+        </Draggable>
     );
 };

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
@@ -1,31 +1,181 @@
 "use client";
 
+import { DragDropContext, Droppable } from "@hello-pangea/dnd";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
-import { ListWithCard } from "@/types";
+import { updateCardOrder } from "@/actions/update-card-order";
+import { updateListOrder } from "@/actions/update-list-order";
+import { useAction } from "@/hooks/useAction";
+import { ListWithCards } from "@/types";
 
 import { ListForm } from "./list-form";
 import { ListItem } from "./list-item";
 
 interface ListContainerProps {
-    data: ListWithCard;
+    data: ListWithCards[];
     boardId: string;
+}
+
+function reorder<T>(list: T[], startIndex: number, endIndex: number) {
+    const result = Array.from(list);
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+
+    return result;
 }
 
 export const ListContainer = ({ data, boardId }: ListContainerProps) => {
     const [orderedData, setOrderedData] = useState(data);
 
+    const { execute: executeUpdateListOrder } = useAction(updateListOrder, {
+        onSuccess: () => {
+            toast.success("List reordered!");
+        },
+        onError: (error) => {
+            toast.error(error);
+        },
+    });
+
+    const { execute: executeUpdateCardOrder } = useAction(updateCardOrder, {
+        onSuccess: () => {
+            toast.success("Card reordered!");
+        },
+        onError: (error) => {
+            toast.error(error);
+        },
+    });
+
     useEffect(() => {
         setOrderedData(data);
     }, [data]);
 
+    const onDragEnd = (result: any) => {
+        const { destination, source, type } = result;
+
+        if (!destination) {
+            return;
+        }
+
+        // Если будет дропнут на ту же позицию, то ничего не делаем
+        if (
+            destination.droppableId === source.droppableId &&
+            destination.index === source.index
+        ) {
+            return;
+        }
+
+        // Если дропаем список
+        if (type === "list") {
+            const items = reorder(
+                orderedData,
+                source.index,
+                destination.index
+            ).map((item, index) => ({ ...item, order: index }));
+
+            // На фронте делаем визуальное отображение перемещения (локально)
+            setOrderedData(items);
+
+            // На сервере меняем порядок списка
+            executeUpdateListOrder({ items, boardId });
+        }
+
+        // Если дропаем отдельную карточку
+        if (type === "card") {
+            let newOrderedData = [...orderedData];
+
+            // Из какого списка и в какой перебрасываем карточку
+            // Получаем исходный список карточки
+            const sourceList = newOrderedData.find(
+                (list) => list.id === source.droppableId
+            );
+            // Получаем список, в который перебрасываем
+            const destList = newOrderedData.find(
+                (list) => list.id === destination.droppableId
+            );
+
+            if (!sourceList || !destList) {
+                return;
+            }
+
+            // Если карточек в исходном списке нет
+            if (!sourceList.cards) {
+                sourceList.cards = [];
+            }
+
+            // Есть ли карточки в списке, в который перемещаем
+            if (!destList.cards) {
+                destList.cards = [];
+            }
+
+            // Перемещаем карточку в тот же список, то именно в этом списке меняем порядок
+            if (source.droppableId === destination.droppableId) {
+                const reorderedCards = reorder(
+                    sourceList.cards,
+                    source.index,
+                    destination.index
+                );
+
+                reorderedCards.forEach((card, idx) => {
+                    card.order = idx;
+                });
+
+                sourceList.cards = reorderedCards;
+
+                // Меняем порядок на фронте
+                setOrderedData(newOrderedData);
+
+                // Меняем на бэке порядок
+                executeUpdateCardOrder({ boardId, items: reorderedCards });
+            } else {
+                // Если перемещаем карточку в другой список
+                // 1. Удаляем карточку из исходного списка
+                const [movedCard] = sourceList.cards.splice(source.index, 1);
+
+                // 2. Даем новый listId этой карточке
+                movedCard.listId = destination.droppableId;
+
+                // 3. Добавляем карточку в новый список
+                destList.cards.splice(destination.index, 0, movedCard);
+
+                // 4. Меняем порядок в исходном списке, т.к. убрали карточку
+                sourceList.cards.forEach((card, idx) => {
+                    card.order = idx;
+                });
+
+                // 5. Обновляем порядок в другом списке, т.к. добавили карточку
+                destList.cards.forEach((card, idx) => {
+                    card.order = idx;
+                });
+
+                // Меняем порядок на фронте
+                setOrderedData(newOrderedData);
+
+                // Меняем порядок на бэке
+                executeUpdateCardOrder({ boardId, items: destList.cards });
+            }
+        }
+    };
+
     return (
-        <ol className="flex gap-x-3 h-full">
-            {orderedData.map((list: ListWithCard, index: number) => (
-                <ListItem key={list.id} index={index} data={list} />
-            ))}
-            <ListForm />
-            <div className="flex-shrink-0 w-1" />
-        </ol>
+        <DragDropContext onDragEnd={onDragEnd}>
+            {/* type="list" */}
+            <Droppable droppableId="list" type="list" direction="horizontal">
+                {(provided) => (
+                    <ol
+                        {...provided.droppableProps}
+                        ref={provided.innerRef}
+                        className="flex gap-x-3 h-full"
+                    >
+                        {orderedData.map((list, index) => (
+                            <ListItem key={list.id} index={index} data={list} />
+                        ))}
+                        {provided.placeholder}
+                        <ListForm />
+                        <div className="flex-shrink-0 w-1" />
+                    </ol>
+                )}
+            </Droppable>
+        </DragDropContext>
     );
 };

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { ElementRef, useRef, useState } from "react";
+import { Draggable, Droppable } from "@hello-pangea/dnd";
 
 import { cn } from "@/lib/utils";
-import { ListWithCard } from "@/types";
+import { ListWithCards } from "@/types";
 
 import { ListHeader } from "./list-header";
 import { CardForm } from "./card-form";
 import { CardItem } from "./card-item";
 
 interface ListItemProps {
-    data: ListWithCard;
+    data: ListWithCards;
     index: number;
 }
 
@@ -31,27 +32,50 @@ export const ListItem = ({ data, index }: ListItemProps) => {
     };
 
     return (
-        <li className="shrink-0 h-full w-[272px] select-none">
-            <div className="w-full rounded-md bg-[#f1f2f4] shadow-md pb-2">
-                <ListHeader onAddCard={enableEditing} data={data} />
-                <ol
-                    className={cn(
-                        "mx-1 px-1 py-0.5 flex flex-col gap-y-2",
-                        data.cards.length > 0 ? "mt-2" : "mt-0"
-                    )}
+        <Draggable draggableId={data.id} index={index}>
+            {(provided) => (
+                <li
+                    {...provided.draggableProps}
+                    ref={provided.innerRef}
+                    className="shrink-0 h-full w-[272px] select-none"
                 >
-                    {data.cards.map((card, index) => (
-                        <CardItem key={card.id} index={index} data={card} />
-                    ))}
-                </ol>
-                <CardForm
-                    ref={textareaRef}
-                    listId={data.id}
-                    isEditing={isEditing}
-                    enableEditig={enableEditing}
-                    disableEditing={disableEditing}
-                />
-            </div>
-        </li>
+                    <div
+                        {...provided.dragHandleProps}
+                        className="w-full rounded-md bg-[#f1f2f4] shadow-md pb-2"
+                    >
+                        <ListHeader onAddCard={enableEditing} data={data} />
+                        {/* type="card" */}
+                        <Droppable droppableId={data.id} type="card">
+                            {(provided) => (
+                                <ol
+                                    ref={provided.innerRef}
+                                    {...provided.droppableProps}
+                                    className={cn(
+                                        "mx-1 px-1 py-0.5 flex flex-col gap-y-2",
+                                        data.cards.length > 0 ? "mt-2" : "mt-0"
+                                    )}
+                                >
+                                    {data.cards.map((card, index) => (
+                                        <CardItem
+                                            key={card.id}
+                                            index={index}
+                                            data={card}
+                                        />
+                                    ))}
+                                    {provided.placeholder}
+                                </ol>
+                            )}
+                        </Droppable>
+                        <CardForm
+                            ref={textareaRef}
+                            listId={data.id}
+                            isEditing={isEditing}
+                            enableEditig={enableEditing}
+                            disableEditing={disableEditing}
+                        />
+                    </div>
+                </li>
+            )}
+        </Draggable>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^4.27.4",
+        "@hello-pangea/dnd": "^16.5.0",
         "@prisma/client": "^5.7.0",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -313,6 +314,24 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-16.5.0.tgz",
+      "integrity": "sha512-n+am6O32jo/CFXciCysz83lPM3I3F58FJw4uS44TceieymcyxQSfzK5OhzPAKrVBZktmuOI6Zim9WABTMtXv4A==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "css-box-model": "^1.2.1",
+        "memoize-one": "^6.0.0",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^8.1.3",
+        "redux": "^4.2.1",
+        "use-memo-one": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
@@ -1399,6 +1418,15 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -1446,8 +1474,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "devOptional": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.10",
@@ -1463,7 +1490,6 @@
       "version": "18.2.41",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.41.tgz",
       "integrity": "sha512-CwOGr/PiLiNBxEBqpJ7fO3kocP/2SSuC9fpH5K7tusrg4xPSRT/193rzolYwQnTN02We/ATXKnb6GqA5w4fRxw==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1482,8 +1508,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "devOptional": true
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -1503,6 +1528,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.13.1",
@@ -2242,6 +2272,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2256,8 +2294,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "devOptional": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3402,6 +3439,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -4024,6 +4069,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4727,6 +4777,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -4753,8 +4808,50 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -4840,6 +4937,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5434,6 +5539,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/to-no-case": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
@@ -5687,6 +5797,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^4.27.4",
+    "@hello-pangea/dnd": "^16.5.0",
     "@prisma/client": "^5.7.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,5 @@
 import { Card, List } from "@prisma/client";
 
-export type ListWithCard = List & { cards: Card[] };
+export type ListWithCards = List & { cards: Card[] };
 
 export type CardWithList = Card & { list: List };


### PR DESCRIPTION
Added new feature that can reorder lists and cards w/ drag n drop. @hello-pangea/dnd package used here. It's ease to use. First, order will change on the front and then it's will change on back. Also added update-list-order and update-card-order server actions 